### PR TITLE
Point manual/local testing docs at exampleFolder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,11 @@ Review these files when implicated (relative to root)
 
 - If a prompt/interaction is testable, create a test before implementation if possible. If not possible, inform the user and create one after implementation.
 - To validate UI/behavior changes end-to-end without a human, run `npm run test:e2e` (Playwright drives an isolated app; see /TESTING.md and /e2e/README.md).
+- Default to `MEDIA_ROOT=./exampleFolder` for any manual/local run of the
+  dev server, not a real photo library — face clusters, moment stacks, and
+  embeddings live in one shared index/DB per `MEDIA_ROOT`, so concurrent
+  sessions against the same real library step on each other's analysis
+  state. See /TESTING.md under "Manual/local testing".
 - If a prompt/interaction could be reflected in a prettier/linting change, suggest updating
   those configurations.
 - If a misunderstanding occurs, ensure the learnings are captured in documentation or comments

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -48,3 +48,6 @@ npm --prefix client run dev
 ```
 
 Open `http://localhost:5173`.
+
+Set `MEDIA_ROOT=./exampleFolder` (instead of a real photo library) for
+local dev/testing — see `TESTING.md` under "Manual/local testing".

--- a/TESTING.md
+++ b/TESTING.md
@@ -15,3 +15,23 @@ and the implementation details benefit from testing to manage their complexity.
   auth disabled), so a UI/behavior change can be validated without a human. First
   run needs `npm run test:e2e:install`. See `e2e/README.md` for isolation details
   and how to add tests.
+
+## Manual/local testing
+
+When running the dev server by hand to poke at a feature (not via the e2e
+suite), point it at `server/exampleFolder` instead of a real photo library:
+
+```
+MEDIA_ROOT=./exampleFolder npm --prefix server run start
+```
+
+`exampleFolder` is a small, diverse fixture (Live Photos, an embedded
+motion photo, GPS/camera/keyword-tag metadata, a burst/moment-cluster set, a
+synthetic face-clustering set, nested album folders) purpose-built to
+exercise real ingestion/analysis code paths without touching a real library.
+This matters beyond convenience: face clusters, moment stacks, and
+embeddings live in one shared index/DB per `MEDIA_ROOT`, so two people (or
+agents) testing against the same real library at once will step on each
+other's analysis state. Only point at a real library when the task
+specifically needs real-world data that doesn't reproduce against the
+fixture.


### PR DESCRIPTION
## Summary
- Follow-up to #10: updates `AGENTS.md`, `GETTING_STARTED.md`, and `TESTING.md` to tell people/agents to run the dev server against `server/exampleFolder` (`MEDIA_ROOT=./exampleFolder`) for manual/local testing, the same way `e2e/playwright.config.ts` already does for the automated suite.
- Motivation: face clusters, moment stacks, and embeddings all live in one shared index/DB per `MEDIA_ROOT` — not worktree-isolated — so concurrent sessions testing against the same real library step on each other's analysis state. Docs-only change, no code.